### PR TITLE
Composer 2.0 Deprecation Warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "net9/FicoraEPP",
+    "name": "net9/ficora-epp",
     "type": "module",
     "description": "Ficora EPP module for WHMCS",
     "license": "GPLv2",


### PR DESCRIPTION
Composer 2.0 Deprecation Warning 
This is a warning fix for https://github.com/net9-oy/whmcs-ficoraepp/issues/21 for Compose 2.0 adoption