### PR TITLE
Fix for missing isfinnish parameter

### DIFF
--- a/ficoraepp.php
+++ b/ficoraepp.php
@@ -269,7 +269,7 @@ class FicoraModule
                 null,
                 $extraInfo->registrantType !== 0 ? $extraInfo->registerNumber : null
             );
-            $postal->setIsFinnish($details['Country'] === 'FI');
+            $postal->setIsFinnish($details['Country'] === 'FI' ? '1' : '0');
             $contact = new eppContact(
                 $postal,
                 $details['Email Address'],

--- a/net9FicoraEppUpdateContactRequest.php
+++ b/net9FicoraEppUpdateContactRequest.php
@@ -48,6 +48,8 @@ class net9FicoraEppUpdateContactRequest extends eppUpdateContactRequest
          *
          * There is no Metaregistrar EPP fix yet, pull request after this one is validated
          */
+        $contactPostalInfo->appendChild($this->createElement('contact:isfinnish', $postalInfo->getIsFinnish()));
+
         if ($postalInfo->getFirstName() && $this->ficoraIdentityType === 0) {
             $contactPostalInfo->appendChild($this->createElement('contact:firstname', $postalInfo->getFirstName()));
         }


### PR DESCRIPTION
Fixes issue https://github.com/net9-oy/whmcs-ficoraepp/issues/26

Added conditional check for ` $postal->setIsFinnish($details['Country'] === 'FI') ? '1' : '0'` because **setFinnish** function wrongly uses `htmlspecialchars($isFinnish, ENT_COMPAT, "UTF-8");` because when it receives **false** boolean value, the result of the function is an empty string.